### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -57,100 +57,67 @@
     - TRIAL release pushed out.  Aiming to improve docs and maybe
       hit rest of RT queue before a full release.
 
-2004-06-01   Sean M. Burke <sburke@cpan.org>
-
-   Release 2.04 -- just cosmetic doc changes
-
-   Also, bumping all the version numbers up to 2.04 just for fun.
+2.04      2004-06-01   Sean M. Burke <sburke@cpan.org>
+    - just cosmetic doc changes
+    - Also, bumping all the version numbers up to 2.04 just for fun.
 
 
-2002-11-22   Sean M. Burke <sburke@cpan.org>
-
-   Release 2.03 -- minor bugfix
-   The lack of \plain's in HTML::FormatRTF's output was confusing some
-   formatters.  Fixed.
-
-
-2002-11-16   Sean M. Burke <sburke@cpan.org>
-
-   Release 2.02 -- minor bugfix
-
-   No big bug reports on the previous version, so maybe it's not so
-   experimental after all!
-
-   Changed the set_version_tag method in HTML::Formatter to avoid some
-   undef warnings that "James W. Durkin" <jwd@phonogram.net> found.
+2.03      2002-11-22   Sean M. Burke <sburke@cpan.org>
+    - minor bugfix
+      The lack of \plain's in HTML::FormatRTF's output was confusing some
+      formatters.  Fixed.
 
 
-2002-11-07   Sean M. Burke <sburke@cpan.org>
+2.02      2002-11-16   Sean M. Burke <sburke@cpan.org>
+    - minor bugfix
+      Changed the set_version_tag method in HTML::Formatter to avoid some
+      undef warnings that "James W. Durkin" <jwd@phonogram.net> found.
 
-   Release 2.01 - experimental major version change
-
-   Added HTML::FormatRTF.
-   Lots of internal changes to HTML::FormatPS and HTML::Formatter.
-   Added format_file and format_string methods to HTML::Formatter.
-   Lots of little tidying up in the docs.
-
-
-2002-10-29   Sean M. Burke <sburke@cpan.org>
-
-   Release 1.24
-
-   Just taking it over from Gisle, and releasing this to make sure
-   CPAN et al register this change.
+      No big bug reports on the previous version, so maybe it's not so
+      experimental after all!
 
 
+2.01      2002-11-07   Sean M. Burke <sburke@cpan.org>
+    - experimental major version change
+    - Added HTML::FormatRTF.
+    - Lots of internal changes to HTML::FormatPS and HTML::Formatter.
+    - Added format_file and format_string methods to HTML::Formatter.
+    - Lots of little tidying up in the docs.
 
 
-
-2000-06-09   Gisle Aas <gisle@ActiveState.com>
-
-   Release 1.23
-
-   Skip <script> and <style> stuff.
+1.24      2002-10-29   Sean M. Burke <sburke@cpan.org>
+    - Just taking it over from Gisle, and releasing this to make sure
+      CPAN et al register this change.
 
 
-
-1999-12-16   Gisle Aas <gisle@aas.no>
-
-   Release HTML-Format-1.22
-
-   Splitted off HTML::Format* modules from HTML-Tree when Sean M. Burke
-   took over maintainance.  You should have HTML-Tree version 0.61 or
-   better installed before installing this.
-
-   Added some simple formatter tests.
+1.23      2000-06-09   Gisle Aas <gisle@ActiveState.com>
+    - Skip <script> and <style> stuff.
 
 
-
-1999-12-15   Gisle Aas <gisle@aas.no>
-
-   Release HTML-Tree-0.53
-
-   Make it compatible with HTML-Parser-3.00
-
-
-
-1999-11-10   Gisle Aas <gisle@aas.no>
-
-   Release 0.52
-
-   Fix SYNOPSIS for HTML::FormatText as suggested by
-   Michael G Schwern <schwern@pobox.com>
-
-   Updated my email address.
+1.22      1999-12-16   Gisle Aas <gisle@aas.no>
+    - Release HTML-Format-1.22
+    - Splitted off HTML::Format* modules from HTML-Tree when Sean M. Burke
+      took over maintainance.  You should have HTML-Tree version 0.61 or
+      better installed before installing this.
+    - Added some simple formatter tests.
 
 
-
-1998-07-07   Gisle Aas <aas@sn.no>
-
-   Release 0.51
-
-   Avoid new warnings introduced by perl5.004_70
+0.53      1999-12-15   Gisle Aas <gisle@aas.no>
+    - Release HTML-Tree-0.53
+    - Make it compatible with HTML-Parser-3.00
 
 
+0.52      1999-11-10   Gisle Aas <gisle@aas.no>
+    - Fix SYNOPSIS for HTML::FormatText as suggested by
+      Michael G Schwern <schwern@pobox.com>
+    - Updated my email address.
 
-1998-04-01   Gisle Aas <aas@sn.no>
 
-   Release 0.50, the HTML::* modules the dealt with HTML syntax trees
-   was unbundled from libwww-perl-5.22.
+0.51      1998-07-07   Gisle Aas <aas@sn.no>
+    - Avoid new warnings introduced by perl5.004_70
+
+
+0.50 1998-04-01   Gisle Aas <aas@sn.no>
+    - The HTML::* modules the dealt with HTML syntax trees
+      was unbundled from libwww-perl-5.22.
+


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec. The main change was putting the version number at the start of the header line for all the older releases.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
